### PR TITLE
Voter-only constructor for Region.java

### DIFF
--- a/DevelopmentConventions.md
+++ b/DevelopmentConventions.md
@@ -2,8 +2,8 @@
 
 This document describes intended and preferred conventions
 for development and maintenance of the Redistricting a Region software product.
-* [Agile Principles](/developmentConventions.md#Agile-Principles)
-* [Coding Convention Guide](/developmentConventions.md#Coding-Convention-Guide)
+* [Agile Principles](/DevelopmentConventions.md#Agile-Principles)
+* [Coding Convention Guide](/DevelopmentConventions.md#Coding-Convention-Guide)
 
  
 ## Agile Principles


### PR DESCRIPTION
Resolves MetroCS/redistricting#59

New constructor method for Region.java that takes in only a set of voters.

**Regarding the Additional Design Decisions Needed -** 

- The Voter object throws an exception if location() is null so this does not need to be handled by the constructor.
- The issue of multiple voters in the same region needs to be a separate issue.